### PR TITLE
docs: add start instructions for assistant

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,8 +14,18 @@ An interactive terminal user interface for configuring and managing validators o
 - Git
 
 ## Running
+
+To launch the assistant locally, run the project with Go:
+
 ```bash
 go run .
+```
+
+This will start the interactive terminal UI. If you prefer to build a binary first, run:
+
+```bash
+go build -o validator-assistant
+./validator-assistant
 ```
 
 ## Navigation


### PR DESCRIPTION
## Summary
- clarify how to start the terminal assistant and build a binary

## Testing
- `go test ./...`


------
https://chatgpt.com/codex/tasks/task_e_68959e3b0dec832bb30151defb7cc8c7