### PR TITLE
Enhance Validator Assistant UI with dark theme and responsive layout

### DIFF
--- a/ui/model.go
+++ b/ui/model.go
@@ -18,6 +18,7 @@ const (
 
 type field struct {
 	prompt string
+	tip    string
 	set    func(*config.ValidatorConfig, string)
 }
 
@@ -30,6 +31,9 @@ type model struct {
 	input  textinput.Model
 	fields []field
 	step   int
+
+	width  int
+	height int
 }
 
 func initialModel() model {
@@ -47,35 +51,35 @@ func initialModel() model {
 		},
 		input: ti,
 		fields: []field{
-			{prompt: "Moniker", set: func(c *config.ValidatorConfig, v string) { c.Moniker = v }},
-			{prompt: "Identity", set: func(c *config.ValidatorConfig, v string) { c.Identity = v }},
-			{prompt: "Website", set: func(c *config.ValidatorConfig, v string) { c.Website = v }},
-			{prompt: "Details", set: func(c *config.ValidatorConfig, v string) { c.Details = v }},
-			{prompt: "Chain ID", set: func(c *config.ValidatorConfig, v string) { c.ChainID = v }},
-			{prompt: "External Address", set: func(c *config.ValidatorConfig, v string) { c.Network.ExternalAddress = v }},
-			{prompt: "Persistent Peers", set: func(c *config.ValidatorConfig, v string) { c.Network.PersistentPeers = v }},
-			{prompt: "Seed Mode (true/false)", set: func(c *config.ValidatorConfig, v string) {
+			{prompt: "Moniker", tip: "Human-readable name for your validator. Example: MyValidator", set: func(c *config.ValidatorConfig, v string) { c.Moniker = v }},
+			{prompt: "Identity", tip: "Optional identity signature such as a Keybase ID.", set: func(c *config.ValidatorConfig, v string) { c.Identity = v }},
+			{prompt: "Website", tip: "Validator website URL.", set: func(c *config.ValidatorConfig, v string) { c.Website = v }},
+			{prompt: "Details", tip: "Additional details about your validator.", set: func(c *config.ValidatorConfig, v string) { c.Details = v }},
+			{prompt: "Chain ID", tip: "Network chain identifier, e.g. cosmoshub-4.", set: func(c *config.ValidatorConfig, v string) { c.ChainID = v }},
+			{prompt: "External Address", tip: "Publicly reachable node address (host:port).", set: func(c *config.ValidatorConfig, v string) { c.Network.ExternalAddress = v }},
+			{prompt: "Persistent Peers", tip: "Comma-separated node IDs for persistent connections.", set: func(c *config.ValidatorConfig, v string) { c.Network.PersistentPeers = v }},
+			{prompt: "Seed Mode (true/false)", tip: "Run the node in seed mode?", set: func(c *config.ValidatorConfig, v string) {
 				c.Network.SeedMode = strings.ToLower(v) == "true"
 			}},
-			{prompt: "Pex (true/false)", set: func(c *config.ValidatorConfig, v string) {
+			{prompt: "Pex (true/false)", tip: "Enable peer exchange?", set: func(c *config.ValidatorConfig, v string) {
 				c.Network.Pex = strings.ToLower(v) == "true"
 			}},
-			{prompt: "Addr Book Strict (true/false)", set: func(c *config.ValidatorConfig, v string) {
+			{prompt: "Addr Book Strict (true/false)", tip: "Strict address book policy.", set: func(c *config.ValidatorConfig, v string) {
 				c.Network.AddrBookStrict = strings.ToLower(v) == "true"
 			}},
-			{prompt: "Validator Key", set: func(c *config.ValidatorConfig, v string) { c.Keys.ValidatorKey = v }},
-			{prompt: "Keyring Backend", set: func(c *config.ValidatorConfig, v string) { c.Keys.KeyringBackend = v }},
-			{prompt: "Key Name", set: func(c *config.ValidatorConfig, v string) { c.Keys.KeyName = v }},
-			{prompt: "DB Backend", set: func(c *config.ValidatorConfig, v string) { c.Consensus.DBBackend = v }},
-			{prompt: "Fast Sync (true/false)", set: func(c *config.ValidatorConfig, v string) {
+			{prompt: "Validator Key", tip: "Path to validator private key file.", set: func(c *config.ValidatorConfig, v string) { c.Keys.ValidatorKey = v }},
+			{prompt: "Keyring Backend", tip: "Keyring backend (os|file|test).", set: func(c *config.ValidatorConfig, v string) { c.Keys.KeyringBackend = v }},
+			{prompt: "Key Name", tip: "Name of the key in keyring.", set: func(c *config.ValidatorConfig, v string) { c.Keys.KeyName = v }},
+			{prompt: "DB Backend", tip: "Database backend (goleveldb|rocksdb|boltdb).", set: func(c *config.ValidatorConfig, v string) { c.Consensus.DBBackend = v }},
+			{prompt: "Fast Sync (true/false)", tip: "Use fast blockchain sync?", set: func(c *config.ValidatorConfig, v string) {
 				c.Consensus.FastSync = strings.ToLower(v) == "true"
 			}},
-			{prompt: "Log Level", set: func(c *config.ValidatorConfig, v string) { c.Consensus.LogLevel = v }},
-			{prompt: "Commission Rate (%)", set: func(c *config.ValidatorConfig, v string) {
+			{prompt: "Log Level", tip: "Logging verbosity (info|debug|error).", set: func(c *config.ValidatorConfig, v string) { c.Consensus.LogLevel = v }},
+			{prompt: "Commission Rate (%)", tip: "Percentage commission for delegators.", set: func(c *config.ValidatorConfig, v string) {
 				f, _ := strconv.ParseFloat(v, 64)
 				c.Economics.CommissionRate = f
 			}},
-			{prompt: "Min Self Delegation", set: func(c *config.ValidatorConfig, v string) {
+			{prompt: "Min Self Delegation", tip: "Minimum self-bond required.", set: func(c *config.ValidatorConfig, v string) {
 				i, _ := strconv.Atoi(v)
 				c.Economics.MinSelfDelegation = i
 			}},

--- a/ui/start.go
+++ b/ui/start.go
@@ -4,6 +4,6 @@ import tea "github.com/charmbracelet/bubbletea"
 
 // Start launches the Bubble Tea program.
 func Start() error {
-	p := tea.NewProgram(initialModel())
+	p := tea.NewProgram(initialModel(), tea.WithAltScreen())
 	return p.Start()
 }

--- a/ui/styles.go
+++ b/ui/styles.go
@@ -3,11 +3,16 @@ package ui
 import "github.com/charmbracelet/lipgloss"
 
 var (
-	// Vibrant color palette for a more playful UI.
-	logoStyle    = lipgloss.NewStyle().Foreground(lipgloss.Color("#F4B400")).Bold(true)
-	titleStyle   = lipgloss.NewStyle().Foreground(lipgloss.Color("#FF8C00")).Bold(true).MarginBottom(1)
-	itemStyle    = lipgloss.NewStyle().Foreground(lipgloss.Color("#E0E0E0")).PaddingLeft(2)
-	cursorStyle  = lipgloss.NewStyle().Foreground(lipgloss.Color("#F4B400"))
-	paneStyle    = lipgloss.NewStyle().BorderStyle(lipgloss.RoundedBorder()).BorderForeground(lipgloss.Color("#F4B400")).Padding(1)
-	previewStyle = lipgloss.NewStyle().Padding(1).Foreground(lipgloss.Color("#888888"))
+	logoStyle   = lipgloss.NewStyle().Foreground(lipgloss.Color("#FF79C6")).Bold(true)
+	titleStyle  = lipgloss.NewStyle().Foreground(lipgloss.Color("#BD93F9")).Bold(true)
+	headerStyle = lipgloss.NewStyle().Background(lipgloss.Color("#1E1E1E")).Foreground(lipgloss.Color("#F8F8F2")).Padding(1)
+	footerStyle = lipgloss.NewStyle().Background(lipgloss.Color("#1E1E1E")).Foreground(lipgloss.Color("#F8F8F2")).Padding(1)
+
+	itemStyle   = lipgloss.NewStyle().Foreground(lipgloss.Color("#F8F8F2")).PaddingLeft(2)
+	cursorStyle = lipgloss.NewStyle().Foreground(lipgloss.Color("#50FA7B"))
+
+	paneStyle    = lipgloss.NewStyle().BorderStyle(lipgloss.RoundedBorder()).BorderForeground(lipgloss.Color("#BD93F9")).Padding(1)
+	previewStyle = lipgloss.NewStyle().Foreground(lipgloss.Color("#F8F8F2")).Padding(1)
+	promptStyle  = lipgloss.NewStyle().Foreground(lipgloss.Color("#FF79C6")).Bold(true)
+	tipStyle     = lipgloss.NewStyle().Foreground(lipgloss.Color("#8BE9FD")).Italic(true)
 )

--- a/ui/update.go
+++ b/ui/update.go
@@ -6,6 +6,13 @@ import (
 )
 
 func (m model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
+	switch msg := msg.(type) {
+	case tea.WindowSizeMsg:
+		m.width = msg.Width
+		m.height = msg.Height
+		return m, nil
+	}
+
 	switch m.state {
 	case stateMainMenu:
 		return m.updateMainMenu(msg)

--- a/ui/view.go
+++ b/ui/view.go
@@ -9,33 +9,65 @@ import (
 )
 
 func (m model) View() string {
-	logo := logoStyle.Render(utils.LoadLogo())
-	header := logo + "\n" + titleStyle.Render("Nectar Validator Assistant")
-
+	body := ""
 	switch m.state {
 	case stateMainMenu:
-		var b strings.Builder
-		for i, choice := range m.choices {
-			cursor := " "
-			if m.cursor == i {
-				cursor = cursorStyle.Render(">")
-			}
-			b.WriteString(fmt.Sprintf("%s %s\n", cursor, itemStyle.Render(choice)))
-		}
-		b.WriteString("\n[↑/↓] move  [Enter] select  [q] quit")
-		return header + "\n\n" + b.String()
+		body = m.mainMenuView()
 	case stateCreateValidator:
-		left := fmt.Sprintf("%s\n\n%s", m.fields[m.step].prompt, m.input.View())
-		preview := m.cfg.ToYAML()
-		if preview == "" {
-			preview = "# configuration preview"
-		}
-		content := lipgloss.JoinHorizontal(lipgloss.Top,
-			paneStyle.Render(left),
-			paneStyle.Render(previewStyle.Render(preview)),
-		)
-		footer := "\n[Esc] back  [Enter] next  [Ctrl+C] quit"
-		return header + "\n" + content + footer
+		body = m.createValidatorView()
 	}
-	return header
+	return lipgloss.JoinVertical(lipgloss.Left, m.headerView(), body, m.footerView())
+}
+
+func (m model) headerView() string {
+	ascii := lipgloss.PlaceHorizontal(m.width, lipgloss.Center, logoStyle.Render(utils.LoadLogo()))
+	functions := lipgloss.PlaceHorizontal(m.width, lipgloss.Center, strings.Join(m.choices, " | "))
+	title := lipgloss.PlaceHorizontal(m.width, lipgloss.Center, titleStyle.Render(m.currentTitle()))
+	content := ascii + "\n" + functions + "\n" + title
+	return headerStyle.Width(m.width).Render(content)
+}
+
+func (m model) footerView() string {
+	help := ""
+	switch m.state {
+	case stateMainMenu:
+		help = "[↑/↓] move  [Enter] select  [q] quit"
+	case stateCreateValidator:
+		help = "[Esc] back  [Enter] next  [Ctrl+C] quit"
+	}
+	return footerStyle.Width(m.width).Render(help)
+}
+
+func (m model) mainMenuView() string {
+	var b strings.Builder
+	for i, choice := range m.choices {
+		cursor := " "
+		if m.cursor == i {
+			cursor = cursorStyle.Render(">")
+		}
+		b.WriteString(fmt.Sprintf("%s %s\n", cursor, itemStyle.Render(choice)))
+	}
+	return lipgloss.PlaceHorizontal(m.width, lipgloss.Left, b.String())
+}
+
+func (m model) createValidatorView() string {
+	prompt := promptStyle.Render(m.fields[m.step].prompt)
+	tip := tipStyle.Render(m.fields[m.step].tip)
+	left := fmt.Sprintf("%s\n%s\n\n%s", prompt, tip, m.input.View())
+	preview := m.cfg.ToYAML()
+	if preview == "" {
+		preview = "# configuration preview"
+	}
+	leftPane := paneStyle.Width(m.width / 2).Render(left)
+	rightPane := paneStyle.Width(m.width / 2).Render(previewStyle.Render(preview))
+	return lipgloss.JoinHorizontal(lipgloss.Top, leftPane, rightPane)
+}
+
+func (m model) currentTitle() string {
+	switch m.state {
+	case stateCreateValidator:
+		return "Validator Creation Assistant"
+	default:
+		return "Main Menu"
+	}
 }


### PR DESCRIPTION
## Summary
- Add field tooltips, track window size, and store dimensions in model
- Introduce themed header/footer, tooltips, and equal-width panes for validator creation
- Apply cohesive dark theme and launch program in alt screen mode

## Testing
- `go vet ./...`
- `go build ./...`


------
https://chatgpt.com/codex/tasks/task_e_6896e6c42f98832bbf85fb62751c0976