### PR TITLE
feat(ui): add navigation controls and external launch

### DIFF
--- a/ui/model.go
+++ b/ui/model.go
@@ -31,6 +31,11 @@ type model struct {
 	input  textinput.Model
 	fields []field
 	step   int
+	// responses keeps the values entered for each field so we can
+	// navigate backward and forward through the wizard.
+	responses []string
+	// function is the currently selected high level action, e.g. "Create New Validator".
+	function string
 
 	width  int
 	height int
@@ -39,6 +44,40 @@ type model struct {
 func initialModel() model {
 	ti := newInput()
 	ti.Placeholder = ""
+	fields := []field{
+		{prompt: "Moniker", tip: "Human-readable name for your validator. Example: MyValidator", set: func(c *config.ValidatorConfig, v string) { c.Moniker = v }},
+		{prompt: "Identity", tip: "Optional identity signature such as a Keybase ID.", set: func(c *config.ValidatorConfig, v string) { c.Identity = v }},
+		{prompt: "Website", tip: "Validator website URL.", set: func(c *config.ValidatorConfig, v string) { c.Website = v }},
+		{prompt: "Details", tip: "Additional details about your validator.", set: func(c *config.ValidatorConfig, v string) { c.Details = v }},
+		{prompt: "Chain ID", tip: "Network chain identifier, e.g. cosmoshub-4.", set: func(c *config.ValidatorConfig, v string) { c.ChainID = v }},
+		{prompt: "External Address", tip: "Publicly reachable node address (host:port).", set: func(c *config.ValidatorConfig, v string) { c.Network.ExternalAddress = v }},
+		{prompt: "Persistent Peers", tip: "Comma-separated node IDs for persistent connections.", set: func(c *config.ValidatorConfig, v string) { c.Network.PersistentPeers = v }},
+		{prompt: "Seed Mode (true/false)", tip: "Run the node in seed mode?", set: func(c *config.ValidatorConfig, v string) {
+			c.Network.SeedMode = strings.ToLower(v) == "true"
+		}},
+		{prompt: "Pex (true/false)", tip: "Enable peer exchange?", set: func(c *config.ValidatorConfig, v string) {
+			c.Network.Pex = strings.ToLower(v) == "true"
+		}},
+		{prompt: "Addr Book Strict (true/false)", tip: "Strict address book policy.", set: func(c *config.ValidatorConfig, v string) {
+			c.Network.AddrBookStrict = strings.ToLower(v) == "true"
+		}},
+		{prompt: "Validator Key", tip: "Path to validator private key file.", set: func(c *config.ValidatorConfig, v string) { c.Keys.ValidatorKey = v }},
+		{prompt: "Keyring Backend", tip: "Keyring backend (os|file|test).", set: func(c *config.ValidatorConfig, v string) { c.Keys.KeyringBackend = v }},
+		{prompt: "Key Name", tip: "Name of the key in keyring.", set: func(c *config.ValidatorConfig, v string) { c.Keys.KeyName = v }},
+		{prompt: "DB Backend", tip: "Database backend (goleveldb|rocksdb|boltdb).", set: func(c *config.ValidatorConfig, v string) { c.Consensus.DBBackend = v }},
+		{prompt: "Fast Sync (true/false)", tip: "Use fast blockchain sync?", set: func(c *config.ValidatorConfig, v string) {
+			c.Consensus.FastSync = strings.ToLower(v) == "true"
+		}},
+		{prompt: "Log Level", tip: "Logging verbosity (info|debug|error).", set: func(c *config.ValidatorConfig, v string) { c.Consensus.LogLevel = v }},
+		{prompt: "Commission Rate (%)", tip: "Percentage commission for delegators.", set: func(c *config.ValidatorConfig, v string) {
+			f, _ := strconv.ParseFloat(v, 64)
+			c.Economics.CommissionRate = f
+		}},
+		{prompt: "Min Self Delegation", tip: "Minimum self-bond required.", set: func(c *config.ValidatorConfig, v string) {
+			i, _ := strconv.Atoi(v)
+			c.Economics.MinSelfDelegation = i
+		}},
+	}
 	return model{
 		state: stateMainMenu,
 		choices: []string{
@@ -49,41 +88,9 @@ func initialModel() model {
 			"Troubleshooting & Reset",
 			"Exit",
 		},
-		input: ti,
-		fields: []field{
-			{prompt: "Moniker", tip: "Human-readable name for your validator. Example: MyValidator", set: func(c *config.ValidatorConfig, v string) { c.Moniker = v }},
-			{prompt: "Identity", tip: "Optional identity signature such as a Keybase ID.", set: func(c *config.ValidatorConfig, v string) { c.Identity = v }},
-			{prompt: "Website", tip: "Validator website URL.", set: func(c *config.ValidatorConfig, v string) { c.Website = v }},
-			{prompt: "Details", tip: "Additional details about your validator.", set: func(c *config.ValidatorConfig, v string) { c.Details = v }},
-			{prompt: "Chain ID", tip: "Network chain identifier, e.g. cosmoshub-4.", set: func(c *config.ValidatorConfig, v string) { c.ChainID = v }},
-			{prompt: "External Address", tip: "Publicly reachable node address (host:port).", set: func(c *config.ValidatorConfig, v string) { c.Network.ExternalAddress = v }},
-			{prompt: "Persistent Peers", tip: "Comma-separated node IDs for persistent connections.", set: func(c *config.ValidatorConfig, v string) { c.Network.PersistentPeers = v }},
-			{prompt: "Seed Mode (true/false)", tip: "Run the node in seed mode?", set: func(c *config.ValidatorConfig, v string) {
-				c.Network.SeedMode = strings.ToLower(v) == "true"
-			}},
-			{prompt: "Pex (true/false)", tip: "Enable peer exchange?", set: func(c *config.ValidatorConfig, v string) {
-				c.Network.Pex = strings.ToLower(v) == "true"
-			}},
-			{prompt: "Addr Book Strict (true/false)", tip: "Strict address book policy.", set: func(c *config.ValidatorConfig, v string) {
-				c.Network.AddrBookStrict = strings.ToLower(v) == "true"
-			}},
-			{prompt: "Validator Key", tip: "Path to validator private key file.", set: func(c *config.ValidatorConfig, v string) { c.Keys.ValidatorKey = v }},
-			{prompt: "Keyring Backend", tip: "Keyring backend (os|file|test).", set: func(c *config.ValidatorConfig, v string) { c.Keys.KeyringBackend = v }},
-			{prompt: "Key Name", tip: "Name of the key in keyring.", set: func(c *config.ValidatorConfig, v string) { c.Keys.KeyName = v }},
-			{prompt: "DB Backend", tip: "Database backend (goleveldb|rocksdb|boltdb).", set: func(c *config.ValidatorConfig, v string) { c.Consensus.DBBackend = v }},
-			{prompt: "Fast Sync (true/false)", tip: "Use fast blockchain sync?", set: func(c *config.ValidatorConfig, v string) {
-				c.Consensus.FastSync = strings.ToLower(v) == "true"
-			}},
-			{prompt: "Log Level", tip: "Logging verbosity (info|debug|error).", set: func(c *config.ValidatorConfig, v string) { c.Consensus.LogLevel = v }},
-			{prompt: "Commission Rate (%)", tip: "Percentage commission for delegators.", set: func(c *config.ValidatorConfig, v string) {
-				f, _ := strconv.ParseFloat(v, 64)
-				c.Economics.CommissionRate = f
-			}},
-			{prompt: "Min Self Delegation", tip: "Minimum self-bond required.", set: func(c *config.ValidatorConfig, v string) {
-				i, _ := strconv.Atoi(v)
-				c.Economics.MinSelfDelegation = i
-			}},
-		},
+		input:     ti,
+		fields:    fields,
+		responses: make([]string, len(fields)),
 	}
 }
 

--- a/ui/start.go
+++ b/ui/start.go
@@ -1,9 +1,35 @@
 package ui
 
-import tea "github.com/charmbracelet/bubbletea"
+import (
+	"os"
+	"os/exec"
+	"runtime"
 
-// Start launches the Bubble Tea program.
+	tea "github.com/charmbracelet/bubbletea"
+)
+
+// Start launches the Bubble Tea program. If possible, it spawns a new
+// terminal window so the assistant runs in its own container outside the
+// current shell.
 func Start() error {
+	if os.Getenv("VA_CHILD") != "1" {
+		exe, err := os.Executable()
+		if err == nil {
+			var cmd *exec.Cmd
+			switch runtime.GOOS {
+			case "darwin":
+				cmd = exec.Command("open", "-a", "Terminal", exe)
+			case "windows":
+				cmd = exec.Command("cmd", "/c", "start", exe)
+			default:
+				cmd = exec.Command("x-terminal-emulator", "-e", exe)
+			}
+			cmd.Env = append(os.Environ(), "VA_CHILD=1")
+			if err := cmd.Start(); err == nil {
+				return nil
+			}
+		}
+	}
 	p := tea.NewProgram(initialModel(), tea.WithAltScreen())
 	return p.Start()
 }

--- a/ui/update.go
+++ b/ui/update.go
@@ -43,8 +43,9 @@ func (m model) updateMainMenu(msg tea.Msg) (tea.Model, tea.Cmd) {
 			}
 			if choice == "Create New Validator" {
 				m.state = stateCreateValidator
+				m.function = choice
 				m.step = 0
-				m.input.SetValue("")
+				m.input.SetValue(m.responses[m.step])
 				m.input.Placeholder = m.fields[m.step].prompt
 				return m, textinput.Blink
 			}
@@ -63,16 +64,28 @@ func (m model) updateCreateValidator(msg tea.Msg) (tea.Model, tea.Cmd) {
 			return m, tea.Quit
 		case "esc":
 			m.state = stateMainMenu
+			m.function = ""
 			return m, nil
-		case "enter":
+		case "shift+tab":
+			if m.step > 0 {
+				m.responses[m.step] = m.input.Value()
+				m.fields[m.step].set(&m.cfg, m.input.Value())
+				m.step--
+				m.input.SetValue(m.responses[m.step])
+				m.input.Placeholder = m.fields[m.step].prompt
+			}
+			return m, nil
+		case "tab", "enter":
+			m.responses[m.step] = m.input.Value()
 			m.fields[m.step].set(&m.cfg, m.input.Value())
-			m.step++
-			if m.step >= len(m.fields) {
-				m.state = stateMainMenu
+			if m.step < len(m.fields)-1 {
+				m.step++
+				m.input.SetValue(m.responses[m.step])
+				m.input.Placeholder = m.fields[m.step].prompt
 				return m, nil
 			}
-			m.input.SetValue("")
-			m.input.Placeholder = m.fields[m.step].prompt
+			m.state = stateMainMenu
+			m.function = ""
 			return m, nil
 		}
 	}

--- a/ui/view.go
+++ b/ui/view.go
@@ -21,9 +21,16 @@ func (m model) View() string {
 
 func (m model) headerView() string {
 	ascii := lipgloss.PlaceHorizontal(m.width, lipgloss.Center, logoStyle.Render(utils.LoadLogo()))
-	functions := lipgloss.PlaceHorizontal(m.width, lipgloss.Center, strings.Join(m.choices, " | "))
+	var functionLine string
+	if m.state != stateMainMenu && m.function != "" {
+		functionLine = lipgloss.PlaceHorizontal(m.width, lipgloss.Center, m.function)
+	}
 	title := lipgloss.PlaceHorizontal(m.width, lipgloss.Center, titleStyle.Render(m.currentTitle()))
-	content := ascii + "\n" + functions + "\n" + title
+	content := ascii
+	if functionLine != "" {
+		content += "\n" + functionLine
+	}
+	content += "\n" + title
 	return headerStyle.Width(m.width).Render(content)
 }
 
@@ -33,7 +40,7 @@ func (m model) footerView() string {
 	case stateMainMenu:
 		help = "[↑/↓] move  [Enter] select  [q] quit"
 	case stateCreateValidator:
-		help = "[Esc] back  [Enter] next  [Ctrl+C] quit"
+		help = "[Esc] menu  [Shift+Tab] prev  [Tab/Enter] next  [Ctrl+C] quit"
 	}
 	return footerStyle.Width(m.width).Render(help)
 }


### PR DESCRIPTION
## Summary
- spawn assistant in a new terminal window when possible
- show only the active function in the header
- allow stepping backward/forward through create-validator prompts

## Testing
- `go vet ./...`
- `go build ./...`
- `go test ./...`


------
https://chatgpt.com/codex/tasks/task_e_6896effd9894832ba5df83d2e9c772ba