### PR TITLE
Skip new terminal when running via go run

### DIFF
--- a/ui/start.go
+++ b/ui/start.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"os"
 	"os/exec"
+	"path/filepath"
 	"runtime"
 	"strings"
 
@@ -18,25 +19,29 @@ func Start() error {
 	if os.Getenv("VA_CHILD") != "1" {
 		exe, err := os.Executable()
 		if err == nil {
-			var cmd *exec.Cmd
-			switch runtime.GOOS {
-			case "darwin":
-				script := fmt.Sprintf(`tell application "Terminal" to do script "export VA_CHILD=1; %s"`, shellEscape(exe))
-				cmd = exec.Command("osascript", "-e", script)
-			case "windows":
-				cmd = exec.Command("cmd", "/c", "start", "", exe)
-				cmd.Env = append(os.Environ(), "VA_CHILD=1")
-			default:
-				if os.Getenv("DISPLAY") != "" {
-					if _, err := exec.LookPath("x-terminal-emulator"); err == nil {
-						cmd = exec.Command("x-terminal-emulator", "-e", exe)
-						cmd.Env = append(os.Environ(), "VA_CHILD=1")
+			exe = filepath.Clean(exe)
+			temp := filepath.Clean(os.TempDir())
+			if !strings.HasPrefix(exe, temp+string(os.PathSeparator)) {
+				var cmd *exec.Cmd
+				switch runtime.GOOS {
+				case "darwin":
+					script := fmt.Sprintf(`tell application "Terminal" to do script "export VA_CHILD=1; %s"`, shellEscape(exe))
+					cmd = exec.Command("osascript", "-e", script)
+				case "windows":
+					cmd = exec.Command("cmd", "/c", "start", "", exe)
+					cmd.Env = append(os.Environ(), "VA_CHILD=1")
+				default:
+					if os.Getenv("DISPLAY") != "" {
+						if _, err := exec.LookPath("x-terminal-emulator"); err == nil {
+							cmd = exec.Command("x-terminal-emulator", "-e", exe)
+							cmd.Env = append(os.Environ(), "VA_CHILD=1")
+						}
 					}
 				}
-			}
-			if cmd != nil {
-				if err := cmd.Run(); err == nil {
-					return nil
+				if cmd != nil {
+					if err := cmd.Run(); err == nil {
+						return nil
+					}
 				}
 			}
 		}


### PR DESCRIPTION
## Summary
- detect when executable is in Go's temp build dir and run directly instead of spawning new terminal

## Testing
- `go vet ./...`
- `go build ./...`
- `go test ./...`


------
https://chatgpt.com/codex/tasks/task_e_689703b79790832b909daa4f147672d6