### PR TITLE
Fix text input handling and refresh dark theme

### DIFF
--- a/ui/styles.go
+++ b/ui/styles.go
@@ -8,10 +8,11 @@ var (
 	headerStyle = lipgloss.NewStyle().Background(lipgloss.Color("#1E1E1E")).Foreground(lipgloss.Color("#F8F8F2")).Padding(1)
 	footerStyle = lipgloss.NewStyle().Background(lipgloss.Color("#1E1E1E")).Foreground(lipgloss.Color("#F8F8F2")).Padding(1)
 
+	bodyStyle   = lipgloss.NewStyle().Background(lipgloss.Color("#121212")).Foreground(lipgloss.Color("#F8F8F2"))
 	itemStyle   = lipgloss.NewStyle().Foreground(lipgloss.Color("#F8F8F2")).PaddingLeft(2)
 	cursorStyle = lipgloss.NewStyle().Foreground(lipgloss.Color("#50FA7B"))
 
-	paneStyle    = lipgloss.NewStyle().BorderStyle(lipgloss.RoundedBorder()).BorderForeground(lipgloss.Color("#BD93F9")).Padding(1)
+	paneStyle    = lipgloss.NewStyle().Background(lipgloss.Color("#1F1F1F")).BorderStyle(lipgloss.RoundedBorder()).BorderForeground(lipgloss.Color("#BD93F9")).Padding(1)
 	previewStyle = lipgloss.NewStyle().Foreground(lipgloss.Color("#F8F8F2")).Padding(1)
 	promptStyle  = lipgloss.NewStyle().Foreground(lipgloss.Color("#FF79C6")).Bold(true)
 	tipStyle     = lipgloss.NewStyle().Foreground(lipgloss.Color("#8BE9FD")).Italic(true)

--- a/ui/update.go
+++ b/ui/update.go
@@ -47,6 +47,7 @@ func (m model) updateMainMenu(msg tea.Msg) (tea.Model, tea.Cmd) {
 				m.step = 0
 				m.input.SetValue(m.responses[m.step])
 				m.input.Placeholder = m.fields[m.step].prompt
+				m.input.Focus()
 				return m, textinput.Blink
 			}
 		}
@@ -65,6 +66,7 @@ func (m model) updateCreateValidator(msg tea.Msg) (tea.Model, tea.Cmd) {
 		case "esc":
 			m.state = stateMainMenu
 			m.function = ""
+			m.input.Blur()
 			return m, nil
 		case "shift+tab":
 			if m.step > 0 {
@@ -73,6 +75,7 @@ func (m model) updateCreateValidator(msg tea.Msg) (tea.Model, tea.Cmd) {
 				m.step--
 				m.input.SetValue(m.responses[m.step])
 				m.input.Placeholder = m.fields[m.step].prompt
+				m.input.Focus()
 			}
 			return m, nil
 		case "tab", "enter":
@@ -82,10 +85,12 @@ func (m model) updateCreateValidator(msg tea.Msg) (tea.Model, tea.Cmd) {
 				m.step++
 				m.input.SetValue(m.responses[m.step])
 				m.input.Placeholder = m.fields[m.step].prompt
+				m.input.Focus()
 				return m, nil
 			}
 			m.state = stateMainMenu
 			m.function = ""
+			m.input.Blur()
 			return m, nil
 		}
 	}

--- a/ui/view.go
+++ b/ui/view.go
@@ -16,6 +16,7 @@ func (m model) View() string {
 	case stateCreateValidator:
 		body = m.createValidatorView()
 	}
+	body = bodyStyle.Width(m.width).Render(body)
 	return lipgloss.JoinVertical(lipgloss.Left, m.headerView(), body, m.footerView())
 }
 


### PR DESCRIPTION
## Summary
- ensure validator setup input field gains focus and blurs appropriately
- refine dark theme with contrasted body and card backgrounds

## Testing
- `go build -v ./...`


------
https://chatgpt.com/codex/tasks/task_e_689719dd522c832b95aeedfc4c42bbab