### PR TITLE
Enhance validator setup UI with themed progress

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -12,6 +12,7 @@ require (
 require (
 	github.com/atotto/clipboard v0.1.4 // indirect
 	github.com/aymanbagabas/go-osc52/v2 v2.0.1 // indirect
+	github.com/charmbracelet/harmonica v0.2.0 // indirect
 	github.com/containerd/console v1.0.4-0.20230313162750-1ae8d489ac81 // indirect
 	github.com/lucasb-eyer/go-colorful v1.2.0 // indirect
 	github.com/mattn/go-isatty v0.0.18 // indirect

--- a/go.sum
+++ b/go.sum
@@ -6,6 +6,8 @@ github.com/charmbracelet/bubbles v0.18.0 h1:PYv1A036luoBGroX6VWjQIE9Syf2Wby2oOl/
 github.com/charmbracelet/bubbles v0.18.0/go.mod h1:08qhZhtIwzgrtBjAcJnij1t1H0ZRjwHyGsy6AL11PSw=
 github.com/charmbracelet/bubbletea v0.25.0 h1:bAfwk7jRz7FKFl9RzlIULPkStffg5k6pNt5dywy4TcM=
 github.com/charmbracelet/bubbletea v0.25.0/go.mod h1:EN3QDR1T5ZdWmdfDzYcqOCAps45+QIJbLOBxmVNWNNg=
+github.com/charmbracelet/harmonica v0.2.0 h1:8NxJWRWg/bzKqqEaaeFNipOu77YR5t8aSwG4pgaUBiQ=
+github.com/charmbracelet/harmonica v0.2.0/go.mod h1:KSri/1RMQOZLbw7AHqgcBycp8pgJnQMYYT8QZRqZ1Ao=
 github.com/charmbracelet/lipgloss v0.9.1 h1:PNyd3jvaJbg4jRHKWXnCj1akQm4rh8dbEzN1p/u1KWg=
 github.com/charmbracelet/lipgloss v0.9.1/go.mod h1:1mPmG4cxScwUQALAAnacHaigiiHB9Pmr+v1VEawJl6I=
 github.com/containerd/console v1.0.4-0.20230313162750-1ae8d489ac81 h1:q2hJAaP1k2wIvVRd/hEHD7lacgqrCPS+k8g1MndzfWY=

--- a/ui/model.go
+++ b/ui/model.go
@@ -1,25 +1,28 @@
 package ui
 
 import (
-	"strconv"
-	"strings"
+        "strconv"
+        "strings"
 
-	"github.com/charmbracelet/bubbles/textinput"
-	tea "github.com/charmbracelet/bubbletea"
-	"github.com/this-nightowl/validator-assistant/config"
+        "github.com/charmbracelet/bubbles/progress"
+        "github.com/charmbracelet/bubbles/textinput"
+        tea "github.com/charmbracelet/bubbletea"
+        "github.com/this-nightowl/validator-assistant/config"
 )
 
 type state int
 
 const (
-	stateMainMenu state = iota
-	stateCreateValidator
+        stateMainMenu state = iota
+        stateCreateValidator
+        stateReviewValidator
 )
 
 type field struct {
-	prompt string
-	tip    string
-	set    func(*config.ValidatorConfig, string)
+        prompt   string
+        tip      string
+        required bool
+        set      func(*config.ValidatorConfig, string)
 }
 
 type model struct {
@@ -37,61 +40,63 @@ type model struct {
 	// function is the currently selected high level action, e.g. "Create New Validator".
 	function string
 
-	width  int
-	height int
+        width    int
+        height   int
+        progress progress.Model
 }
 
 func initialModel() model {
-	ti := newInput()
-	ti.Placeholder = ""
-	fields := []field{
-		{prompt: "Moniker", tip: "Human-readable name for your validator. Example: MyValidator", set: func(c *config.ValidatorConfig, v string) { c.Moniker = v }},
-		{prompt: "Identity", tip: "Optional identity signature such as a Keybase ID.", set: func(c *config.ValidatorConfig, v string) { c.Identity = v }},
-		{prompt: "Website", tip: "Validator website URL.", set: func(c *config.ValidatorConfig, v string) { c.Website = v }},
-		{prompt: "Details", tip: "Additional details about your validator.", set: func(c *config.ValidatorConfig, v string) { c.Details = v }},
-		{prompt: "Chain ID", tip: "Network chain identifier, e.g. cosmoshub-4.", set: func(c *config.ValidatorConfig, v string) { c.ChainID = v }},
-		{prompt: "External Address", tip: "Publicly reachable node address (host:port).", set: func(c *config.ValidatorConfig, v string) { c.Network.ExternalAddress = v }},
-		{prompt: "Persistent Peers", tip: "Comma-separated node IDs for persistent connections.", set: func(c *config.ValidatorConfig, v string) { c.Network.PersistentPeers = v }},
-		{prompt: "Seed Mode (true/false)", tip: "Run the node in seed mode?", set: func(c *config.ValidatorConfig, v string) {
-			c.Network.SeedMode = strings.ToLower(v) == "true"
-		}},
-		{prompt: "Pex (true/false)", tip: "Enable peer exchange?", set: func(c *config.ValidatorConfig, v string) {
-			c.Network.Pex = strings.ToLower(v) == "true"
-		}},
-		{prompt: "Addr Book Strict (true/false)", tip: "Strict address book policy.", set: func(c *config.ValidatorConfig, v string) {
-			c.Network.AddrBookStrict = strings.ToLower(v) == "true"
-		}},
-		{prompt: "Validator Key", tip: "Path to validator private key file.", set: func(c *config.ValidatorConfig, v string) { c.Keys.ValidatorKey = v }},
-		{prompt: "Keyring Backend", tip: "Keyring backend (os|file|test).", set: func(c *config.ValidatorConfig, v string) { c.Keys.KeyringBackend = v }},
-		{prompt: "Key Name", tip: "Name of the key in keyring.", set: func(c *config.ValidatorConfig, v string) { c.Keys.KeyName = v }},
-		{prompt: "DB Backend", tip: "Database backend (goleveldb|rocksdb|boltdb).", set: func(c *config.ValidatorConfig, v string) { c.Consensus.DBBackend = v }},
-		{prompt: "Fast Sync (true/false)", tip: "Use fast blockchain sync?", set: func(c *config.ValidatorConfig, v string) {
-			c.Consensus.FastSync = strings.ToLower(v) == "true"
-		}},
-		{prompt: "Log Level", tip: "Logging verbosity (info|debug|error).", set: func(c *config.ValidatorConfig, v string) { c.Consensus.LogLevel = v }},
-		{prompt: "Commission Rate (%)", tip: "Percentage commission for delegators.", set: func(c *config.ValidatorConfig, v string) {
-			f, _ := strconv.ParseFloat(v, 64)
-			c.Economics.CommissionRate = f
-		}},
-		{prompt: "Min Self Delegation", tip: "Minimum self-bond required.", set: func(c *config.ValidatorConfig, v string) {
-			i, _ := strconv.Atoi(v)
-			c.Economics.MinSelfDelegation = i
-		}},
-	}
-	return model{
-		state: stateMainMenu,
-		choices: []string{
-			"Create New Validator",
-			"Update Existing Validator",
-			"Grafana Dashboard Setup",
-			"Take or Restore Snapshot",
-			"Troubleshooting & Reset",
-			"Exit",
-		},
-		input:     ti,
-		fields:    fields,
-		responses: make([]string, len(fields)),
-	}
+        ti := newInput()
+        ti.Placeholder = ""
+        fields := []field{
+                {prompt: "Moniker", tip: "Human-readable name for your validator. Example: MyValidator", required: true, set: func(c *config.ValidatorConfig, v string) { c.Moniker = v }},
+                {prompt: "Identity", tip: "Optional identity signature such as a Keybase ID.", required: false, set: func(c *config.ValidatorConfig, v string) { c.Identity = v }},
+                {prompt: "Website", tip: "Validator website URL.", required: false, set: func(c *config.ValidatorConfig, v string) { c.Website = v }},
+                {prompt: "Details", tip: "Additional details about your validator.", required: false, set: func(c *config.ValidatorConfig, v string) { c.Details = v }},
+                {prompt: "Chain ID", tip: "Network chain identifier, e.g. cosmoshub-4.", required: true, set: func(c *config.ValidatorConfig, v string) { c.ChainID = v }},
+                {prompt: "External Address", tip: "Publicly reachable node address (host:port).", required: true, set: func(c *config.ValidatorConfig, v string) { c.Network.ExternalAddress = v }},
+                {prompt: "Persistent Peers", tip: "Comma-separated node IDs for persistent connections.", required: false, set: func(c *config.ValidatorConfig, v string) { c.Network.PersistentPeers = v }},
+                {prompt: "Seed Mode (true/false)", tip: "Run the node in seed mode?", required: false, set: func(c *config.ValidatorConfig, v string) {
+                        c.Network.SeedMode = strings.ToLower(v) == "true"
+                }},
+                {prompt: "Pex (true/false)", tip: "Enable peer exchange?", required: false, set: func(c *config.ValidatorConfig, v string) {
+                        c.Network.Pex = strings.ToLower(v) == "true"
+                }},
+                {prompt: "Addr Book Strict (true/false)", tip: "Strict address book policy.", required: false, set: func(c *config.ValidatorConfig, v string) {
+                        c.Network.AddrBookStrict = strings.ToLower(v) == "true"
+                }},
+                {prompt: "Validator Key", tip: "Path to validator private key file.", required: true, set: func(c *config.ValidatorConfig, v string) { c.Keys.ValidatorKey = v }},
+                {prompt: "Keyring Backend", tip: "Keyring backend (os|file|test).", required: true, set: func(c *config.ValidatorConfig, v string) { c.Keys.KeyringBackend = v }},
+                {prompt: "Key Name", tip: "Name of the key in keyring.", required: true, set: func(c *config.ValidatorConfig, v string) { c.Keys.KeyName = v }},
+                {prompt: "DB Backend", tip: "Database backend (goleveldb|rocksdb|boltdb).", required: false, set: func(c *config.ValidatorConfig, v string) { c.Consensus.DBBackend = v }},
+                {prompt: "Fast Sync (true/false)", tip: "Use fast blockchain sync?", required: false, set: func(c *config.ValidatorConfig, v string) {
+                        c.Consensus.FastSync = strings.ToLower(v) == "true"
+                }},
+                {prompt: "Log Level", tip: "Logging verbosity (info|debug|error).", required: false, set: func(c *config.ValidatorConfig, v string) { c.Consensus.LogLevel = v }},
+                {prompt: "Commission Rate (%)", tip: "Percentage commission for delegators.", required: false, set: func(c *config.ValidatorConfig, v string) {
+                        f, _ := strconv.ParseFloat(v, 64)
+                        c.Economics.CommissionRate = f
+                }},
+                {prompt: "Min Self Delegation", tip: "Minimum self-bond required.", required: false, set: func(c *config.ValidatorConfig, v string) {
+                        i, _ := strconv.Atoi(v)
+                        c.Economics.MinSelfDelegation = i
+                }},
+        }
+        return model{
+                state: stateMainMenu,
+                choices: []string{
+                        "Create New Validator",
+                        "Update Existing Validator",
+                        "Grafana Dashboard Setup",
+                        "Take or Restore Snapshot",
+                        "Troubleshooting & Reset",
+                        "Exit",
+                },
+                input:     ti,
+                fields:    fields,
+                responses: make([]string, len(fields)),
+                progress:  progress.New(progress.WithGradient("#004aad", "#ffb715"), progress.WithoutPercentage()),
+        }
 }
 
 func (m model) Init() tea.Cmd {

--- a/ui/start.go
+++ b/ui/start.go
@@ -46,8 +46,8 @@ func Start() error {
 			}
 		}
 	}
-	p := tea.NewProgram(initialModel(), tea.WithAltScreen())
-	return p.Start()
+        p := tea.NewProgram(initialModel(), tea.WithAltScreen(), tea.WithMouseAllMotion())
+        return p.Start()
 }
 
 func shellEscape(s string) string {

--- a/ui/styles.go
+++ b/ui/styles.go
@@ -3,16 +3,17 @@ package ui
 import "github.com/charmbracelet/lipgloss"
 
 var (
-	logoStyle   = lipgloss.NewStyle().Foreground(lipgloss.Color("#FF79C6")).Bold(true)
-	titleStyle  = lipgloss.NewStyle().Foreground(lipgloss.Color("#BD93F9")).Bold(true)
-	headerStyle = lipgloss.NewStyle().Background(lipgloss.Color("#1E1E1E")).Foreground(lipgloss.Color("#F8F8F2")).Padding(1)
-	footerStyle = lipgloss.NewStyle().Background(lipgloss.Color("#1E1E1E")).Foreground(lipgloss.Color("#F8F8F2")).Padding(1)
+        logoStyle   = lipgloss.NewStyle().Foreground(lipgloss.Color("#ffb715")).Bold(true)
+        titleStyle  = lipgloss.NewStyle().Foreground(lipgloss.Color("#ffb715")).Bold(true)
+        headerStyle = lipgloss.NewStyle().Background(lipgloss.Color("#004aad")).Foreground(lipgloss.Color("#F8F8F2")).Padding(1)
+        footerStyle = lipgloss.NewStyle().Background(lipgloss.Color("#004aad")).Foreground(lipgloss.Color("#F8F8F2")).Padding(1)
 
-	itemStyle   = lipgloss.NewStyle().Foreground(lipgloss.Color("#F8F8F2")).PaddingLeft(2)
-	cursorStyle = lipgloss.NewStyle().Foreground(lipgloss.Color("#50FA7B"))
+        bodyStyle   = lipgloss.NewStyle().Background(lipgloss.Color("#121212")).Foreground(lipgloss.Color("#F8F8F2"))
+        itemStyle   = lipgloss.NewStyle().Foreground(lipgloss.Color("#F8F8F2")).PaddingLeft(2)
+        cursorStyle = lipgloss.NewStyle().Foreground(lipgloss.Color("#ffb715"))
 
-	paneStyle    = lipgloss.NewStyle().BorderStyle(lipgloss.RoundedBorder()).BorderForeground(lipgloss.Color("#BD93F9")).Padding(1)
-	previewStyle = lipgloss.NewStyle().Foreground(lipgloss.Color("#F8F8F2")).Padding(1)
-	promptStyle  = lipgloss.NewStyle().Foreground(lipgloss.Color("#FF79C6")).Bold(true)
-	tipStyle     = lipgloss.NewStyle().Foreground(lipgloss.Color("#8BE9FD")).Italic(true)
+        paneStyle    = lipgloss.NewStyle().Background(lipgloss.Color("#1a1a1a")).BorderStyle(lipgloss.RoundedBorder()).BorderForeground(lipgloss.Color("#004aad")).Padding(1)
+        previewStyle = lipgloss.NewStyle().Foreground(lipgloss.Color("#F8F8F2")).Padding(1)
+        promptStyle  = lipgloss.NewStyle().Foreground(lipgloss.Color("#ffb715")).Bold(true)
+        tipStyle     = lipgloss.NewStyle().Foreground(lipgloss.Color("#8BE9FD")).Italic(true)
 )

--- a/ui/update.go
+++ b/ui/update.go
@@ -1,28 +1,47 @@
 package ui
 
 import (
-	"github.com/charmbracelet/bubbles/textinput"
-	tea "github.com/charmbracelet/bubbletea"
+        "os"
+        "strings"
+
+        "github.com/charmbracelet/bubbles/textinput"
+        tea "github.com/charmbracelet/bubbletea"
+        "github.com/charmbracelet/bubbles/progress"
+        "github.com/this-nightowl/validator-assistant/config"
 )
 
 func (m model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
-	switch msg := msg.(type) {
-	case tea.WindowSizeMsg:
-		m.width = msg.Width
-		m.height = msg.Height
-		return m, nil
-	}
+        var cmds []tea.Cmd
+        switch msg := msg.(type) {
+        case tea.WindowSizeMsg:
+                m.width = msg.Width
+                m.height = msg.Height
+                m.progress.Width = msg.Width
+        }
 
-	switch m.state {
-	case stateMainMenu:
-		return m.updateMainMenu(msg)
-	case stateCreateValidator:
-		return m.updateCreateValidator(msg)
-	}
-	return m, nil
+        var cmd tea.Cmd
+        var p tea.Model
+        p, cmd = m.progress.Update(msg)
+        if pm, ok := p.(progress.Model); ok {
+                m.progress = pm
+        }
+        cmds = append(cmds, cmd)
+
+        switch m.state {
+        case stateMainMenu:
+                m, cmd = m.updateMainMenu(msg)
+        case stateCreateValidator:
+                m, cmd = m.updateCreateValidator(msg)
+        case stateReviewValidator:
+                m, cmd = m.updateReviewValidator(msg)
+        }
+        if cmd != nil {
+                cmds = append(cmds, cmd)
+        }
+        return m, tea.Batch(cmds...)
 }
 
-func (m model) updateMainMenu(msg tea.Msg) (tea.Model, tea.Cmd) {
+func (m model) updateMainMenu(msg tea.Msg) (model, tea.Cmd) {
 	switch msg := msg.(type) {
 	case tea.KeyMsg:
 		switch msg.String() {
@@ -47,6 +66,7 @@ func (m model) updateMainMenu(msg tea.Msg) (tea.Model, tea.Cmd) {
 				m.step = 0
 				m.input.SetValue(m.responses[m.step])
 				m.input.Placeholder = m.fields[m.step].prompt
+				m.input.Focus()
 				return m, textinput.Blink
 			}
 		}
@@ -54,40 +74,80 @@ func (m model) updateMainMenu(msg tea.Msg) (tea.Model, tea.Cmd) {
 	return m, nil
 }
 
-func (m model) updateCreateValidator(msg tea.Msg) (tea.Model, tea.Cmd) {
-	var cmd tea.Cmd
-	m.input, cmd = m.input.Update(msg)
-	switch msg := msg.(type) {
-	case tea.KeyMsg:
-		switch msg.String() {
-		case "ctrl+c":
-			return m, tea.Quit
-		case "esc":
-			m.state = stateMainMenu
-			m.function = ""
-			return m, nil
-		case "shift+tab":
-			if m.step > 0 {
-				m.responses[m.step] = m.input.Value()
-				m.fields[m.step].set(&m.cfg, m.input.Value())
-				m.step--
-				m.input.SetValue(m.responses[m.step])
-				m.input.Placeholder = m.fields[m.step].prompt
-			}
-			return m, nil
-		case "tab", "enter":
-			m.responses[m.step] = m.input.Value()
-			m.fields[m.step].set(&m.cfg, m.input.Value())
-			if m.step < len(m.fields)-1 {
-				m.step++
-				m.input.SetValue(m.responses[m.step])
-				m.input.Placeholder = m.fields[m.step].prompt
-				return m, nil
-			}
-			m.state = stateMainMenu
-			m.function = ""
-			return m, nil
-		}
-	}
-	return m, cmd
+func (m model) updateCreateValidator(msg tea.Msg) (model, tea.Cmd) {
+        var cmd tea.Cmd
+        m.input, cmd = m.input.Update(msg)
+        switch msg := msg.(type) {
+        case tea.KeyMsg:
+                switch msg.String() {
+                case "ctrl+c":
+                        return m, tea.Quit
+                case "esc":
+                        m.state = stateMainMenu
+                        m.function = ""
+                        m.input.Blur()
+                        return m, nil
+                case "shift+tab":
+                        if m.step > 0 {
+                                m.responses[m.step] = m.input.Value()
+                                m.fields[m.step].set(&m.cfg, m.input.Value())
+                                m.step--
+                                m.input.SetValue(m.responses[m.step])
+                                m.input.Placeholder = m.fields[m.step].prompt
+                                m.input.Focus()
+                        }
+                        return m, nil
+                case "tab", "enter":
+                        val := m.input.Value()
+                        if m.fields[m.step].required && strings.TrimSpace(val) == "" {
+                                return m, nil
+                        }
+                        m.responses[m.step] = val
+                        m.fields[m.step].set(&m.cfg, val)
+                        if m.step < len(m.fields)-1 {
+                                m.step++
+                                m.input.SetValue(m.responses[m.step])
+                                m.input.Placeholder = m.fields[m.step].prompt
+                                m.input.Focus()
+                                return m, nil
+                        }
+                        m.step = len(m.fields)
+                        m.state = stateReviewValidator
+                        m.function = "Review Configuration"
+                        m.input.Blur()
+                        return m, nil
+                }
+        }
+        return m, cmd
+}
+
+func (m model) updateReviewValidator(msg tea.Msg) (model, tea.Cmd) {
+        switch msg := msg.(type) {
+        case tea.KeyMsg:
+                switch msg.String() {
+                case "ctrl+c":
+                        return m, tea.Quit
+                case "esc":
+                        m.state = stateMainMenu
+                        m.function = ""
+                        m.step = 0
+                        return m, nil
+                case "s":
+                        saveConfig(m.cfg)
+                        m.state = stateMainMenu
+                        m.function = ""
+                        m.step = 0
+                        return m, nil
+                case "d":
+                        m.state = stateMainMenu
+                        m.function = ""
+                        m.step = 0
+                        return m, nil
+                }
+        }
+        return m, nil
+}
+
+func saveConfig(cfg config.ValidatorConfig) {
+        _ = os.WriteFile("validator.yaml", []byte(cfg.ToYAML()), 0o644)
 }

--- a/ui/view.go
+++ b/ui/view.go
@@ -1,48 +1,63 @@
 package ui
 
 import (
-	"fmt"
-	"strings"
+        "fmt"
+        "strings"
 
-	"github.com/charmbracelet/lipgloss"
-	"github.com/this-nightowl/validator-assistant/utils"
+        "github.com/charmbracelet/lipgloss"
 )
 
 func (m model) View() string {
-	body := ""
-	switch m.state {
-	case stateMainMenu:
-		body = m.mainMenuView()
-	case stateCreateValidator:
-		body = m.createValidatorView()
-	}
-	return lipgloss.JoinVertical(lipgloss.Left, m.headerView(), body, m.footerView())
+        header := m.headerView()
+        footer := m.footerView()
+        progress := ""
+        if m.state == stateCreateValidator || m.state == stateReviewValidator {
+                progress = m.progressView()
+        }
+
+        body := ""
+        switch m.state {
+        case stateMainMenu:
+                body = m.mainMenuView()
+        case stateCreateValidator:
+                body = m.createValidatorView()
+        case stateReviewValidator:
+                body = m.reviewValidatorView()
+        }
+
+        usedHeight := lipgloss.Height(header) + lipgloss.Height(footer) + lipgloss.Height(progress)
+        bodyHeight := m.height - usedHeight
+        if bodyHeight < 0 {
+                bodyHeight = 0
+        }
+        body = bodyStyle.Width(m.width).Height(bodyHeight).Render(body)
+        return lipgloss.JoinVertical(lipgloss.Left, header, body, progress, footer)
 }
 
 func (m model) headerView() string {
-	ascii := lipgloss.PlaceHorizontal(m.width, lipgloss.Center, logoStyle.Render(utils.LoadLogo()))
-	var functionLine string
-	if m.state != stateMainMenu && m.function != "" {
-		functionLine = lipgloss.PlaceHorizontal(m.width, lipgloss.Center, m.function)
-	}
-	title := lipgloss.PlaceHorizontal(m.width, lipgloss.Center, titleStyle.Render(m.currentTitle()))
-	content := ascii
-	if functionLine != "" {
-		content += "\n" + functionLine
-	}
-	content += "\n" + title
-	return headerStyle.Width(m.width).Render(content)
+        var functionLine string
+        if m.state != stateMainMenu && m.function != "" {
+                functionLine = lipgloss.PlaceHorizontal(m.width, lipgloss.Center, m.function)
+        }
+        title := lipgloss.PlaceHorizontal(m.width, lipgloss.Center, titleStyle.Render(m.currentTitle()))
+        content := title
+        if functionLine != "" {
+                content += "\n" + functionLine
+        }
+        return headerStyle.Width(m.width).Render(content)
 }
 
 func (m model) footerView() string {
-	help := ""
-	switch m.state {
-	case stateMainMenu:
-		help = "[↑/↓] move  [Enter] select  [q] quit"
-	case stateCreateValidator:
-		help = "[Esc] menu  [Shift+Tab] prev  [Tab/Enter] next  [Ctrl+C] quit"
-	}
-	return footerStyle.Width(m.width).Render(help)
+        help := ""
+        switch m.state {
+        case stateMainMenu:
+                help = "[↑/↓] move  [Enter] select  [q] quit"
+        case stateCreateValidator:
+                help = "[Esc] menu  [Shift+Tab] prev  [Tab/Enter] next  [Ctrl+C] quit"
+        case stateReviewValidator:
+                help = "[s] save  [d] deploy  [Esc] menu  [Ctrl+C] quit"
+        }
+        return footerStyle.Width(m.width).Render(help)
 }
 
 func (m model) mainMenuView() string {
@@ -58,23 +73,57 @@ func (m model) mainMenuView() string {
 }
 
 func (m model) createValidatorView() string {
-	prompt := promptStyle.Render(m.fields[m.step].prompt)
-	tip := tipStyle.Render(m.fields[m.step].tip)
-	left := fmt.Sprintf("%s\n%s\n\n%s", prompt, tip, m.input.View())
-	preview := m.cfg.ToYAML()
-	if preview == "" {
-		preview = "# configuration preview"
-	}
-	leftPane := paneStyle.Width(m.width / 2).Render(left)
-	rightPane := paneStyle.Width(m.width / 2).Render(previewStyle.Render(preview))
-	return lipgloss.JoinHorizontal(lipgloss.Top, leftPane, rightPane)
+        pr := m.fields[m.step]
+        promptText := pr.prompt
+        if pr.required {
+                promptText += " *"
+        }
+        prompt := promptStyle.Render(promptText)
+        tipText := pr.tip
+        if pr.required {
+                tipText += " (required)"
+        } else {
+                tipText += " (optional)"
+        }
+        tip := tipStyle.Render(tipText)
+        left := fmt.Sprintf("%s\n%s\n\n%s", prompt, tip, m.input.View())
+        preview := m.cfg.ToYAML()
+        if preview == "" {
+                preview = "# configuration preview"
+        }
+        leftPane := paneStyle.Width(m.width / 2).Render(left)
+        rightPane := paneStyle.Width(m.width / 2).Render(previewStyle.Copy().MaxHeight(10).Render(preview))
+        return lipgloss.JoinHorizontal(lipgloss.Top, leftPane, rightPane)
+}
+
+func (m model) reviewValidatorView() string {
+        preview := m.cfg.ToYAML()
+        if preview == "" {
+                preview = "# configuration preview"
+        }
+        pane := paneStyle.Width(m.width).Render(previewStyle.Copy().MaxHeight(m.height-6).Render(preview))
+        hint := tipStyle.Render("s: save  d: deploy  esc: menu")
+        return lipgloss.JoinVertical(lipgloss.Left, pane, hint)
 }
 
 func (m model) currentTitle() string {
-	switch m.state {
-	case stateCreateValidator:
-		return "Validator Creation Assistant"
-	default:
-		return "Main Menu"
-	}
+        switch m.state {
+        case stateCreateValidator:
+                return "Validator Creation Assistant"
+        case stateReviewValidator:
+                return "Review Configuration"
+        default:
+                return "Main Menu"
+        }
+}
+
+func (m model) progressView() string {
+        percent := 0.0
+        if len(m.fields) > 0 {
+                percent = float64(m.step) / float64(len(m.fields))
+        }
+        if percent > 1 {
+                percent = 1
+        }
+        return m.progress.ViewAs(percent)
 }


### PR DESCRIPTION
## Summary
- adopt #004aad/#ffb715 dark theme with contrasted panes and headers
- add gradient progress bar and review step with save option
- flag required fields and compact config preview; enable mouse input

## Testing
- `go build -v ./...`


------
https://chatgpt.com/codex/tasks/task_e_689719dd522c832b95aeedfc4c42bbab